### PR TITLE
[feat] #49 スライド資料のjsonダウンロード機能追加

### DIFF
--- a/src/app/teacher/editor/page.tsx
+++ b/src/app/teacher/editor/page.tsx
@@ -34,15 +34,36 @@ export default function EditorScreen() {
         addBlock(type, defaultParams);
     };
 
+    // --- 保存のハンドラー ---
+    const handleSave = () => {
+        const slides = useEditorStore.getState().slides;
+        const jsonString = JSON.stringify({
+            version: '1.0.0',
+            updatedAt: new Date().toISOString(),
+            slides: slides
+        }, null, 2);
+        const blob = new Blob([jsonString], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `slide-${new Date().getTime()}.json`;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+    };
+
     return (
         <div className="relative w-screen h-screen bg-gray-100 flex flex-col items-center justify-center font-sans overflow-hidden">
 
             {/* --- ヘッダー --- */}
             <header className="absolute top-0 w-full h-14 bg-white border-b border-gray-200 flex items-center px-6 justify-between z-10">
-                <div className="font-bold text-gray-700">統合教材エディタ</div>
-                <div className="flex gap-2">
-                    <button className="px-4 py-1.5 text-sm bg-gray-100 text-gray-600 rounded hover:bg-gray-200 font-bold transition-colors">プレビュー</button>
-                    <button className="px-4 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 font-bold transition-colors">保存</button>
+                <div className="flex gap-2"><button 
+                        onClick={handleSave}
+                        className="px-4 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 font-bold transition-colors active:scale-95"
+                    >
+                        保存
+                    </button>
                 </div>
             </header>
 


### PR DESCRIPTION
## 概要
- Editorからjsonがダウンロードできるように保存ボタンを追加

## 関連Issue
- #49

## 変更内容
- 

## 残タスク
- DBへの保存は未実装。全体の設計を変更する必要あり
