### PR TITLE
[feat] #55 ブロック選択の修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@dnd-kit/utilities": "^3.2.2",
         "aws-cdk": "^2.1118.2",
         "immer": "^11.1.8",
-        "lucide-react": "^1.18.0",
+        "lucide-react": "^1.23.0",
         "next": "16.1.6",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -6331,9 +6331,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.18.0.tgz",
-      "integrity": "sha512-LZDb7H/0YfM+RJncD0hDQRCAu+vSGODqpe35TuVI8EuXaRjkczbsx7p8dY4J87F/MUSj6bpYqeI8nw8qXaAdmA==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.23.0.tgz",
+      "integrity": "sha512-38BpJcD0JhFosxHApP/BYsBetLpQFRoTRzEzstM/XCc3jsAG7wqaY1lgVwxiUe3xqYE+lNxo2PkCmYwXWrwwIw==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "aws-cdk": "^2.1118.2",
     "immer": "^11.1.8",
-    "lucide-react": "^1.18.0",
+    "lucide-react": "^1.23.0",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/src/app/teacher/editor/page.tsx
+++ b/src/app/teacher/editor/page.tsx
@@ -1,38 +1,12 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import { Rnd } from 'react-rnd';
-
 import { useEditorStore } from '@/stores/useEditorStore';
-import type { BlockType } from '@/types/block';
-import { BLOCK_DEFAULTS } from '@/components/blocks/defaults';
-import Inspector from '@/components/inspectors/Inspector';
 import SlideNavigator from '@/components/editor/SlideNavigator';
 import SlideCanvas from '@/components/editor/SlideCanvas';
-
+import BlockSelector from '@/components/editor/BlockSelector';
+import Inspector from '@/components/inspectors/Inspector';
 
 export default function EditorScreen() {
-
-    // コンポーネントのマウント状態を管理
-    const [isMounted, setIsMounted] = useState(false);
-
-    // Zustand Store から状態と関数を取得
-    const addBlock = useEditorStore((state) => state.addBlock);
-
-    // コンポーネントがクライアント側でマウントされた後に、isMountedをtrueにする
-    useEffect(() => {
-        const timer = setTimeout(() => {
-            setIsMounted(true);
-        }, 0);
-
-        return () => clearTimeout(timer);
-    }, []);
-
-    // --- ブロック追加のハンドラー ---
-    const handleAddBlock = (type: BlockType) => {
-        const defaultParams = BLOCK_DEFAULTS[type] || {};
-        addBlock(type, defaultParams);
-    };
 
     // --- 保存のハンドラー ---
     const handleSave = () => {
@@ -58,7 +32,8 @@ export default function EditorScreen() {
 
             {/* --- ヘッダー --- */}
             <header className="absolute top-0 w-full h-14 bg-white border-b border-gray-200 flex items-center px-6 justify-between z-10">
-                <div className="flex gap-2"><button 
+                <div className="flex gap-2">
+                    <button 
                         onClick={handleSave}
                         className="px-4 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 font-bold transition-colors active:scale-95"
                     >
@@ -67,79 +42,10 @@ export default function EditorScreen() {
                 </div>
             </header>
 
+            {/* --- メインエリア --- */}
             <SlideNavigator />
-
             <SlideCanvas />
-
-            {/* --- 左側：コンポーネントパレット --- */}
-            {isMounted && (
-                <Rnd
-                    default={{ x: 24, y: 96, width: 256, height: 'auto' }}
-                    minWidth={200}
-                    bounds="parent"
-                    dragHandleClassName="palette-drag-handle"
-                    enableResizing={{ right: true, bottom: true, bottomRight: true }}
-                    className="z-20"
-                >
-                    <div className="w-full h-full bg-white/80 backdrop-blur-md shadow-xl rounded-xl border border-gray-200 overflow-hidden flex flex-col">
-                        {/* タイトルバー（ドラッグの取っ手） */}
-                        <div className="palette-drag-handle bg-gray-800 text-white px-3 py-2 text-xs font-bold flex justify-between items-center cursor-move select-none">
-                            <span>コンポーネント</span>
-                            <span className="text-gray-400">≡</span>
-                        </div>
-                        {/* パレットの中身 */}
-                        <div className="p-3 flex flex-col gap-2 overflow-y-auto">
-                            <div className="text-xs font-bold text-gray-400 mb-1">静的要素</div>
-                            <button
-                                onClick={() => handleAddBlock('text')}
-                                className="p-2 border border-gray-200 rounded-lg hover:border-blue-400 hover:bg-blue-50 text-left text-sm text-gray-700 flex items-center gap-2 transition-colors"
-                            >
-                                <span className="text-lg">📝</span> テキスト
-                            </button>
-                            <button
-                                onClick={() => handleAddBlock('h1')}
-                                className="p-2 border border-gray-200 rounded-lg hover:border-blue-400 hover:bg-blue-50 text-left text-sm text-gray-700 flex items-center gap-2 transition-colors"
-                            >
-                                <span className="text-lg">📝</span> 見出し1
-                            </button>
-                            <button
-                                onClick={() => handleAddBlock('h2')}
-                                className="p-2 border border-gray-200 rounded-lg hover:border-blue-400 hover:bg-blue-50 text-left text-sm text-gray-700 flex items-center gap-2 transition-colors"
-                            >
-                                <span className="text-lg">📝</span> 見出し2
-                            </button>
-                            <button
-                                onClick={() => handleAddBlock('h3')}
-                                className="p-2 border border-gray-200 rounded-lg hover:border-blue-400 hover:bg-blue-50 text-left text-sm text-gray-700 flex items-center gap-2 transition-colors"
-                            >
-                                <span className="text-lg">📝</span> 見出し3
-                            </button>
-                            <button
-                                onClick={() => handleAddBlock('h4')}
-                                className="p-2 border border-gray-200 rounded-lg hover:border-blue-400 hover:bg-blue-50 text-left text-sm text-gray-700 flex items-center gap-2 transition-colors"
-                            >
-                                <span className="text-lg">📝</span> 見出し4
-                            </button>
-
-                            <div className="text-xs font-bold text-gray-400 mt-2 mb-1">動的要素</div>
-                            <button
-                                onClick={() => handleAddBlock('counter')}
-                                className="p-2 border border-gray-200 rounded-lg hover:border-blue-400 hover:bg-blue-50 text-left text-sm text-gray-700 flex items-center gap-2 transition-colors"
-                            >
-                                <span className="text-lg">🔢</span> カウンター
-                            </button>
-                            <button
-                                onClick={() => handleAddBlock('roller-coaster')}
-                                className="p-2 border border-gray-200 rounded-lg hover:border-blue-400 hover:bg-blue-50 text-left text-sm text-gray-700 flex items-center gap-2 transition-colors"
-                            >
-                                <span className="text-lg">🎢</span> シミュレータ
-                            </button>
-                        </div>
-                    </div>
-                </Rnd>
-            )}
-
-            {/* --- 右側：ブロック設定 --- */}
+            <BlockSelector />
             <Inspector />
         </div>
     );

--- a/src/components/editor/BlockSelector.tsx
+++ b/src/components/editor/BlockSelector.tsx
@@ -1,0 +1,80 @@
+'use client';
+import { Type, Heading1, Heading2, Heading3, Heading4, RollerCoaster, SquarePlus } from 'lucide-react';
+
+import { Rnd } from 'react-rnd';
+import { useEditorStore } from '@/stores/useEditorStore';
+import type { BlockType } from '@/types/block';
+import { BLOCK_DEFAULTS } from '@/components/blocks/defaults';
+
+// --- BlockSelector | 型定義とデータ ---
+type BlockItem = {
+    type: BlockType;
+    icon: React.ElementType | null;
+    label: string;
+};
+
+const STATIC_ITEMS: BlockItem[] = [
+    { type: 'text', icon: Type, label: 'テキスト' },
+    { type: 'h1', icon: Heading1, label: '見出し1' },
+    { type: 'h2', icon: Heading2, label: '見出し2' },
+    { type: 'h3', icon: Heading3, label: '見出し3' },
+    { type: 'h4', icon: Heading4, label: '見出し4' },
+];
+
+const DYNAMIC_ITEMS: BlockItem[] = [
+    { type: 'roller-coaster', icon: RollerCoaster, label: '力学的エネルギー' },
+    { type: 'counter', icon: SquarePlus, label: 'カウンター' },
+];
+
+// --- BlockSelector | コンポーネント ---
+const BUTTON_CLASS = "p-2 border border-gray-200 rounded-lg hover:border-blue-400 hover:bg-blue-50 text-left text-sm text-gray-700 flex items-center gap-2 transition-colors w-full";
+
+export default function BlockSelector() {
+    const addBlock = useEditorStore((state) => state.addBlock);
+
+    // ブロック追加のハンドラー
+    const handleAddBlock = (type: BlockType) => {
+        const defaultParams = BLOCK_DEFAULTS[type] || {};
+        addBlock(type, defaultParams);
+    };
+
+    // ボタンを生成するヘルパー関数
+    const renderButton = (item: BlockItem) => (
+        <button
+            key={item.type}
+            onClick={() => handleAddBlock(item.type)}
+            className={BUTTON_CLASS}
+        >
+            {item.icon && <item.icon className="w-4 h-4" />}
+            {item.label}
+        </button>
+    );
+
+    return (
+        <Rnd
+            default={{ x: 24, y: 96, width: 256, height: 'auto' }}
+            minWidth={200}
+            bounds="parent"
+            dragHandleClassName="palette-drag-handle"
+            enableResizing={{ right: true, bottom: true, bottomRight: true }}
+            className="z-20"
+        >
+            <div className="w-full h-full bg-white/80 backdrop-blur-md shadow-xl rounded-xl border border-gray-200 overflow-hidden flex flex-col">
+                {/* タイトルバー */}
+                <div className="palette-drag-handle bg-gray-800 text-white px-3 py-2 text-xs font-bold flex justify-between items-center cursor-move select-none">
+                    <span>ブロック選択</span>
+                    <span className="text-gray-400">≡</span>
+                </div>
+
+                {/* ブロック選択の中身 */}
+                <div className="p-3 flex flex-col gap-2 overflow-y-auto">
+                    <div className="text-xs font-bold text-gray-400 mb-1">静的ブロック</div>
+                    {STATIC_ITEMS.map(renderButton)}
+
+                    <div className="text-xs font-bold text-gray-400 mt-2 mb-1">動的ブロック</div>
+                    {DYNAMIC_ITEMS.map(renderButton)}
+                </div>
+            </div>
+        </Rnd>
+    );
+}


### PR DESCRIPTION
## 概要
- スライド教材作成画面のブロック選択について以下の修正をした
- コンポーネント化し、`/editor/BlockSelector.tsx`に
- タイトルを「コンポーネント」から「ブロック選択」に変更
- 「シミュレータ」をRollerCoaster(もしくは適切な何か)に修正
- 静的要素・動的要素の見出しを修正

## 関連Issue
- #55

## 変更内容
| 旧 | 新 |
|--------|--------|
| <img width="194" height="373" alt="image" src="https://github.com/user-attachments/assets/7086fd64-b763-4694-afb7-e09da0b02dea" /> | <img width="196" height="327" alt="image" src="https://github.com/user-attachments/assets/54c2b823-5cf3-46bf-bca8-cc7c6455dea5" /> |

## 今後の実装
- 定数について、/Blocks/config.tsに切り出し、ブロック設定でも使えるようにする
- 現状の実装だと、TextBlockの扱いに困るので別々にする
