### PR TITLE
[chore] #46 テキスト系ブロックの分離

### DIFF
--- a/src/components/blocks/Block.tsx
+++ b/src/components/blocks/Block.tsx
@@ -1,7 +1,12 @@
 import { BlockData } from '@/types/block';
-import CounterBlock from './CounterBlock';
-import RollerCoasterBlock from './RollerCoasterBlock';
+
 import TextBlock from './TextBlock';
+import H1Block from './H1Block';
+import H2Block from './H2Block';
+import H3Block from './H3Block';
+import H4Block from './H4Block';
+import RollerCoasterBlock from './RollerCoasterBlock';
+import CounterBlock from './CounterBlock';
 import ErrorBlock from './ErrorBlock';
 
 interface Props {
@@ -9,27 +14,16 @@ interface Props {
 }
 
 export default function Block({ block }: Props) {
-  
+
   switch (block.type) {
-    
-    // CounterBlock
-    case 'counter':
-      return <CounterBlock {...block.parameters} />;
+    case 'text': return <TextBlock {...block.parameters} />;
+    case 'h1': return <H1Block {...block.parameters} />;
+    case 'h2': return <H2Block {...block.parameters} />;
+    case 'h3': return <H3Block {...block.parameters} />;
+    case 'h4': return <H4Block {...block.parameters} />;
+    case 'counter': return <CounterBlock {...block.parameters} />;
+    case 'roller-coaster': return <RollerCoasterBlock {...block.parameters} />;
 
-    // RollerCoasterBlock
-    case 'roller-coaster':
-      return <RollerCoasterBlock {...block.parameters} />;
-
-    // TextBlock
-    case 'h1':
-    case 'h2':
-    case 'h3':
-    case 'h4':
-    case 'text':
-      return <TextBlock type={block.type} content={block.parameters.content} />;
-
-    // ErrorBlock（不明なタイプのブロック）
-    default:
-      return <ErrorBlock />;
+    default: return <ErrorBlock />;
   }
 }

--- a/src/components/blocks/H1Block.tsx
+++ b/src/components/blocks/H1Block.tsx
@@ -1,0 +1,9 @@
+import type { TextParameters } from '@/types/block';
+
+export const defaultH1Params: Required<TextParameters> = {
+    content: '見出し1',
+};
+
+export default function H1Block({ content = defaultH1Params.content }: TextParameters) {
+    return <h1 className="text-4xl font-bold">{content}</h1>;
+}

--- a/src/components/blocks/H2Block.tsx
+++ b/src/components/blocks/H2Block.tsx
@@ -1,0 +1,9 @@
+import type { TextParameters } from '@/types/block';
+
+export const defaultH2Params: Required<TextParameters> = {
+    content: '見出し2',
+};
+
+export default function H2Block({ content = defaultH2Params.content }: TextParameters) {
+    return <h2 className="text-3xl font-bold">{content}</h2>;
+}

--- a/src/components/blocks/H3Block.tsx
+++ b/src/components/blocks/H3Block.tsx
@@ -1,0 +1,9 @@
+import type { TextParameters } from '@/types/block';
+
+export const defaultH3Params: Required<TextParameters> = {
+    content: '見出し3',
+};
+
+export default function H3Block({ content = defaultH3Params.content }: TextParameters) {
+    return <h3 className="text-2xl font-bold">{content}</h3>;
+}

--- a/src/components/blocks/H4Block.tsx
+++ b/src/components/blocks/H4Block.tsx
@@ -1,0 +1,9 @@
+import type { TextParameters } from '@/types/block';
+
+export const defaultH4Params: Required<TextParameters> = {
+    content: '見出し4',
+};
+
+export default function H4Block({ content = defaultH4Params.content }: TextParameters) {
+    return <h4 className="text-xl font-bold">{content}</h4>;
+}

--- a/src/components/blocks/TextBlock.tsx
+++ b/src/components/blocks/TextBlock.tsx
@@ -1,26 +1,9 @@
-import type { TextBlockData } from '@/types/block';
+import type { TextParameters } from '@/types/block';
 
-// --- TextBlock｜型定義 ---
-export const defaultTextParams: Required<TextBlockData['parameters']> = {
+export const defaultTextParams: Required<TextParameters> = {
     content: 'テキストを入力',
 };
 
-export type TextBlockProps = TextBlockData['parameters'] & {
-    type: TextBlockData['type'];
-};
-
-// --- TextBlock | コンポーネント ---
-export default function TextBlock({
-    type,
-    content = defaultTextParams.content,
-}: TextBlockProps) {
-    
-    switch (type) {
-        case 'h1': return <h1 className="text-4xl font-bold">{content}</h1>;
-        case 'h2': return <h2 className="text-3xl font-bold">{content}</h2>;
-        case 'h3': return <h3 className="text-2xl font-bold">{content}</h3>;
-        case 'h4': return <h4 className="text-xl font-bold">{content}</h4>;
-        case 'text': return <p className="text-base">{content}</p>;
-        default: return null;
-    }
+export default function TextBlock({ content = defaultTextParams.content }: TextParameters) {
+    return <p className="text-base">{content}</p>;
 }

--- a/src/types/block.ts
+++ b/src/types/block.ts
@@ -1,12 +1,12 @@
-export type CounterBlockData = {
-  id: string;
-  type: 'counter';
-  parameters: {
-    initialCount: number;
-    step: number;
-    label: string;
-  };
-}
+// --- テキスト系ブロック ---
+export type TextParameters = {
+  content: string;
+};
+export type TextBlockData = { id: string; type: 'text'; parameters: TextParameters; };
+export type H1BlockData = { id: string; type: 'h1'; parameters: TextParameters; };
+export type H2BlockData = { id: string; type: 'h2'; parameters: TextParameters; };
+export type H3BlockData = { id: string; type: 'h3'; parameters: TextParameters; };
+export type H4BlockData = { id: string; type: 'h4'; parameters: TextParameters; };
 
 export type RollerCoasterBlockData = {
   id: string;
@@ -22,16 +22,25 @@ export type RollerCoasterBlockData = {
   };
 };
 
-export type TextBlockData = {
+export type CounterBlockData = {
   id: string;
-  type: 'h1' | 'h2' | 'h3' | 'h4' | 'text';
+  type: 'counter';
   parameters: {
-    content: string;
+    initialCount: number;
+    step: number;
+    label: string;
   };
-};
+}
 
 // 全てのブロックの型を合体（ユニオン）
-export type BlockData = TextBlockData | CounterBlockData | RollerCoasterBlockData;
+export type BlockData =
+  | TextBlockData
+  | H1BlockData
+  | H2BlockData
+  | H3BlockData
+  | H4BlockData
+  | RollerCoasterBlockData
+  | CounterBlockData;
 
 // ブロックの種類だけを抜き取るユーティリティ型
 export type BlockType = BlockData['type'];


### PR DESCRIPTION
## 概要
- `/blocks/TextBlock.tsx`に記述していたテキスト系ブロックを分離した。これにより、UIもロジックも完全に分離し、開発がしやすい。

## 関連Issue
- #46

## 変更内容
- /blocks/TextBlock.tsx
- /blocks/H1Block.tsx などの追加
- types/blocks.ts 及び/blocks/Block.tsx の修正

## 影響範囲
- 
