### PR TITLE
Feat/#76 update block sort

### DIFF
--- a/src/app/editor/[deckId]/page.tsx
+++ b/src/app/editor/[deckId]/page.tsx
@@ -6,6 +6,7 @@ import EditorFooter from '@/components/editor/EditorFooter';
 import SlideNavigator from '@/components/editor/SlideNavigator';
 import SlideCanvas from '@/components/editor/SlideCanvas';
 import BlockSelector from '@/components/editor/BlockSelector';
+import EditorBlockDndContext from '@/components/editor/EditorBlockDndContext';
 import BlockSettings from '@/src/components/editor/BlockSettings/BlockSettings';
 import { useSaveDeck } from '@/hooks/useSaveDeck';
 
@@ -25,8 +26,10 @@ export default function EditorPage({ params }: { params: Promise<{ deckId: strin
 
             {/* --- メインエリア --- */}
             <SlideNavigator />
-            <SlideCanvas />
-            <BlockSelector />
+            <EditorBlockDndContext>
+                <SlideCanvas />
+                <BlockSelector />
+            </EditorBlockDndContext>
             <BlockSettings />
 
             <EditorFooter saveStatus={saveStatus} />

--- a/src/components/blocks/SortableBlockItem.tsx
+++ b/src/components/blocks/SortableBlockItem.tsx
@@ -25,31 +25,39 @@ export default function SortableBlockItem({ block }: { block: BlockData }) {
         transform: CSS.Transform.toString(transform),
         transition,
         zIndex: isDragging ? 50 : 1,
-        opacity: isDragging ? 0.5 : 1,
     };
 
     return (
         <div
             ref={setNodeRef}
+            data-block-id={block.id}
             style={style}
             className={`relative p-4 rounded-lg border-2 transition-colors cursor-pointer bg-white ${
-                isSelected ? 'border-blue-500 bg-blue-50/30' : 'border-transparent hover:border-gray-200'
+                isDragging
+                    ? 'border-dashed border-blue-300 bg-blue-50/40'
+                    : isSelected
+                        ? 'border-blue-500 bg-blue-50/30'
+                        : 'border-transparent hover:border-gray-200'
             }`}
             onClick={(e) => {
                 e.stopPropagation();
                 setSelectedBlockId(block.id);
             }}
         >
-            {isSelected && (
+            {isSelected && !isDragging && (
                 <div
                     {...attributes}
                     {...listeners}
-                    className="absolute -top-3 -left-3 w-6 h-6 bg-blue-500 text-white rounded-full flex items-center justify-center shadow-sm cursor-grab active:cursor-grabbing hover:scale-110 transition-transform"
+                    className="absolute -top-3 -left-3 w-6 h-6 bg-blue-500 text-white rounded-full flex items-center justify-center shadow-sm cursor-grab active:cursor-grabbing hover:scale-110 transition-transform select-none touch-none"
                 >
                     <span className="text-xs">✥</span>
                 </div>
             )}
-            <Block block={block} />
+            {/* ドラッグ中は実体を非表示にし、見た目はDragOverlay側の固定サイズのプレビューに任せる
+                (この場所のサイズだけはレイアウトの隙間として保持する) */}
+            <div className={isDragging ? 'invisible' : ''}>
+                <Block block={block} />
+            </div>
         </div>
     );
 }

--- a/src/components/blocks/SortableBlockItem.tsx
+++ b/src/components/blocks/SortableBlockItem.tsx
@@ -25,6 +25,7 @@ export default function SortableBlockItem({ block }: { block: BlockData }) {
         transform: CSS.Transform.toString(transform),
         transition,
         zIndex: isDragging ? 50 : 1,
+        opacity: isDragging ? 0.4 : 1,
     };
 
     return (
@@ -32,32 +33,25 @@ export default function SortableBlockItem({ block }: { block: BlockData }) {
             ref={setNodeRef}
             data-block-id={block.id}
             style={style}
-            className={`relative p-4 rounded-lg border-2 transition-colors cursor-pointer bg-white ${
-                isDragging
-                    ? 'border-dashed border-blue-300 bg-blue-50/40'
-                    : isSelected
-                        ? 'border-blue-500 bg-blue-50/30'
-                        : 'border-transparent hover:border-gray-200'
+            className={`group relative p-4 rounded-lg border-2 transition-colors cursor-pointer bg-white ${
+                isSelected ? 'border-blue-500 bg-blue-50/30' : 'border-transparent hover:border-gray-200'
             }`}
             onClick={(e) => {
                 e.stopPropagation();
                 setSelectedBlockId(block.id);
             }}
         >
-            {isSelected && !isDragging && (
-                <div
-                    {...attributes}
-                    {...listeners}
-                    className="absolute -top-3 -left-3 w-6 h-6 bg-blue-500 text-white rounded-full flex items-center justify-center shadow-sm cursor-grab active:cursor-grabbing hover:scale-110 transition-transform select-none touch-none"
-                >
-                    <span className="text-xs">✥</span>
-                </div>
-            )}
-            {/* ドラッグ中は実体を非表示にし、見た目はDragOverlay側の固定サイズのプレビューに任せる
-                (この場所のサイズだけはレイアウトの隙間として保持する) */}
-            <div className={isDragging ? 'invisible' : ''}>
-                <Block block={block} />
+            {/* ドラッグハンドル: ホバー中、または選択中に表示する(Notionに倣い選択なしでも掴めるように) */}
+            <div
+                {...attributes}
+                {...listeners}
+                className={`absolute -top-3 -left-3 w-6 h-6 bg-blue-500 text-white rounded-full flex items-center justify-center shadow-sm cursor-grab active:cursor-grabbing hover:scale-110 transition-opacity select-none touch-none ${
+                    isSelected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+                }`}
+            >
+                <span className="text-xs">✥</span>
             </div>
+            <Block block={block} />
         </div>
     );
 }

--- a/src/components/blocks/TwoColumnBlock.tsx
+++ b/src/components/blocks/TwoColumnBlock.tsx
@@ -1,9 +1,8 @@
 'use client';
 
 import { useRef } from 'react';
-import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useSensor, useSensors, DragEndEvent } from '@dnd-kit/core';
-import { SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy } from '@dnd-kit/sortable';
-import { restrictToVerticalAxis, restrictToFirstScrollableAncestor } from '@dnd-kit/modifiers';
+import { useDroppable } from '@dnd-kit/core';
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 
 import { useEditorStore } from '@/stores/useEditorStore';
 import SortableBlockItem from './SortableBlockItem';
@@ -15,42 +14,27 @@ export const MAX_RATIO = 0.85;
 
 interface ColumnProps {
     containerId: string;
-    columnIndex: number;
     blocks: BlockData[];
 }
 
-function Column({ containerId, columnIndex, blocks }: ColumnProps) {
-    const moveBlock = useEditorStore((state) => state.moveBlock);
-
-    const sensors = useSensors(
-        useSensor(PointerSensor),
-        useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
-    );
-
-    const handleDragEnd = (event: DragEndEvent) => {
-        const { active, over } = event;
-        if (over && active.id !== over.id) {
-            moveBlock(active.id as string, over.id as string);
-        }
-    };
+function Column({ containerId, blocks }: ColumnProps) {
+    const { setNodeRef } = useDroppable({
+        id: containerId,
+        data: { type: 'container', containerId },
+    });
 
     return (
-        <div className="min-w-0 flex flex-col gap-2 py-2">
-            <DndContext
-                id={`two-column-${containerId}-${columnIndex}`}
-                sensors={sensors}
-                collisionDetection={closestCenter}
-                modifiers={[restrictToVerticalAxis, restrictToFirstScrollableAncestor]}
-                onDragEnd={handleDragEnd}
-            >
-                <SortableContext items={blocks.map((b) => b.id)} strategy={verticalListSortingStrategy}>
-                    <div className="flex flex-col gap-2">
-                        {blocks.map((block) => (
-                            <SortableBlockItem key={block.id} block={block} />
-                        ))}
-                    </div>
-                </SortableContext>
-            </DndContext>
+        <div ref={setNodeRef} className="min-w-0 min-h-[48px] h-full flex flex-col gap-2 py-2">
+            <SortableContext id={containerId} items={blocks.map((b) => b.id)} strategy={verticalListSortingStrategy}>
+                <div className="flex flex-col gap-2 flex-1">
+                    {blocks.map((block) => (
+                        <SortableBlockItem key={block.id} block={block} />
+                    ))}
+                    {blocks.length === 0 && (
+                        <div className="flex-1 min-h-[32px] rounded border border-dashed border-gray-200" />
+                    )}
+                </div>
+            </SortableContext>
         </div>
     );
 }
@@ -91,7 +75,7 @@ export default function TwoColumnBlock({ id, columns, ratio }: Props) {
     return (
         <div ref={containerRef} className="flex overflow-x-auto custom-scrollbar" onClick={(e) => e.stopPropagation()}>
             <div style={{ flexGrow: ratio, flexBasis: 0, minWidth: getColumnMinWidth(columns[0]) }}>
-                <Column containerId={id} columnIndex={0} blocks={columns[0]} />
+                <Column containerId={`${id}:0`} blocks={columns[0]} />
             </div>
 
             <div
@@ -102,7 +86,7 @@ export default function TwoColumnBlock({ id, columns, ratio }: Props) {
             </div>
 
             <div style={{ flexGrow: 1 - ratio, flexBasis: 0, minWidth: getColumnMinWidth(columns[1]) }}>
-                <Column containerId={id} columnIndex={1} blocks={columns[1]} />
+                <Column containerId={`${id}:1`} blocks={columns[1]} />
             </div>
         </div>
     );

--- a/src/components/editor/BlockSelector.tsx
+++ b/src/components/editor/BlockSelector.tsx
@@ -1,34 +1,45 @@
 'use client';
 
+import { useDraggable } from '@dnd-kit/core';
 import { Rnd } from 'react-rnd';
 import { useEditorStore } from '@/stores/useEditorStore';
 import type { BlockType } from '@/types/block';
 import { BLOCK_DEFAULTS } from '@/components/blocks/defaults';
 import { STATIC_ITEMS, DYNAMIC_ITEMS, type BlockItem } from '@/components/blocks/blockItems';
+import type { PaletteDragData } from './EditorBlockDndContext';
 
 // --- BlockSelector | コンポーネント ---
-const BUTTON_CLASS = "p-2 border border-gray-200 rounded-lg hover:border-blue-400 hover:bg-blue-50 text-left text-sm text-gray-700 flex items-center gap-2 transition-colors w-full";
+const BUTTON_CLASS = "p-2 border border-gray-200 rounded-lg hover:border-blue-400 hover:bg-blue-50 text-left text-sm text-gray-700 flex items-center gap-2 transition-colors w-full cursor-grab active:cursor-grabbing select-none touch-none";
 
-export default function BlockSelector() {
-    const addBlock = useEditorStore((state) => state.addBlock);
+// クリックでの即時追加と、キャンバスへのドラッグ配置の両方に対応するボタン
+function PaletteButton({ item, onClick }: { item: BlockItem; onClick: () => void }) {
+    const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+        id: `palette:${item.type}`,
+        data: { source: 'palette', blockType: item.type } satisfies PaletteDragData,
+    });
 
-    // ブロック追加のハンドラー
-    const handleAddBlock = (type: BlockType) => {
-        const defaultParams = BLOCK_DEFAULTS[type] || {};
-        addBlock(type, defaultParams);
-    };
-
-    // ボタンを生成するヘルパー関数
-    const renderButton = (item: BlockItem) => (
+    return (
         <button
-            key={item.type}
-            onClick={() => handleAddBlock(item.type)}
-            className={BUTTON_CLASS}
+            ref={setNodeRef}
+            onClick={onClick}
+            className={`${BUTTON_CLASS} ${isDragging ? 'opacity-40' : ''}`}
+            {...attributes}
+            {...listeners}
         >
             {item.icon && <item.icon className="w-4 h-4" />}
             {item.label}
         </button>
     );
+}
+
+export default function BlockSelector() {
+    const addBlock = useEditorStore((state) => state.addBlock);
+
+    // ブロック追加のハンドラー(クリック時)
+    const handleAddBlock = (type: BlockType) => {
+        const defaultParams = BLOCK_DEFAULTS[type] || {};
+        addBlock(type, defaultParams);
+    };
 
     return (
         <Rnd
@@ -49,10 +60,14 @@ export default function BlockSelector() {
                 {/* ブロック選択の中身 */}
                 <div className="p-3 flex flex-col gap-2 overflow-y-auto">
                     <div className="text-xs font-bold text-gray-400 mb-1">静的ブロック</div>
-                    {STATIC_ITEMS.map(renderButton)}
+                    {STATIC_ITEMS.map((item) => (
+                        <PaletteButton key={item.type} item={item} onClick={() => handleAddBlock(item.type)} />
+                    ))}
 
                     <div className="text-xs font-bold text-gray-400 mt-2 mb-1">動的ブロック</div>
-                    {DYNAMIC_ITEMS.map(renderButton)}
+                    {DYNAMIC_ITEMS.map((item) => (
+                        <PaletteButton key={item.type} item={item} onClick={() => handleAddBlock(item.type)} />
+                    ))}
                 </div>
             </div>
         </Rnd>

--- a/src/components/editor/EditorBlockDndContext.tsx
+++ b/src/components/editor/EditorBlockDndContext.tsx
@@ -1,27 +1,24 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import {
     DndContext,
     DragOverlay,
     KeyboardSensor,
     PointerSensor,
     closestCenter,
+    pointerWithin,
     useSensor,
     useSensors,
 } from '@dnd-kit/core';
-import type { DragStartEvent, DragOverEvent, DragEndEvent, Over } from '@dnd-kit/core';
+import type { Active, CollisionDetection, DragEndEvent, DragOverEvent, DragStartEvent, Over } from '@dnd-kit/core';
 import { sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 
 import { useEditorStore } from '@/stores/useEditorStore';
 import { BLOCK_DEFAULTS } from '@/components/blocks/defaults';
+import { STATIC_ITEMS, DYNAMIC_ITEMS } from '@/components/blocks/blockItems';
 import Block from '@/components/blocks/Block';
-import {
-    ROOT_CONTAINER_ID,
-    findBlockById,
-    findContainerIdForBlock,
-    findContainerList,
-} from '@/lib/blockTree';
+import { findBlockById, findContainerList } from '@/lib/blockTree';
 import type { BlockData, BlockType } from '@/types/block';
 
 // BlockSelectorのボタンをドラッグ開始したときに active.data に載せる情報
@@ -43,76 +40,110 @@ function isContainerDropData(data: unknown): data is ContainerDropData {
     return !!data && typeof data === 'object' && (data as ContainerDropData).type === 'container';
 }
 
-// over(ドロップ先候補)から「どのコンテナの何番目に置こうとしているか」を求める
-function resolveOverTarget(over: Over | null, blocks: BlockData[]): { containerId: string; index: number } | null {
-    if (!over) return null;
+const PALETTE_ITEMS_BY_TYPE = Object.fromEntries(
+    [...STATIC_ITEMS, ...DYNAMIC_ITEMS].map((item) => [item.type, item])
+);
 
+// 挿入位置を示すインジケーターの見た目情報。実データは動かさず、これだけを描画する
+type Indicator =
+    | { kind: 'line'; top: number; left: number; width: number }
+    | { kind: 'empty'; top: number; left: number; width: number; height: number };
+
+// over(ドロップ先候補)への挿入位置(コンテナID+index)と、それを示すインジケーターを同時に求める。
+// sortableアイテムにホバーしている場合は、ドラッグ中の要素がその上半分/下半分どちらにあるかで
+// 「前に挿入」か「後ろに挿入」かを判定する
+function resolveDrag(
+    active: Active,
+    over: Over | null,
+    blocks: BlockData[]
+): { containerId: string; index: number; indicator: Indicator } | null {
+    if (!over || !over.rect) return null;
     const data = over.data.current;
-    if (isSortableItemData(data)) {
-        return { containerId: data.sortable.containerId, index: data.sortable.index };
-    }
+
     if (isContainerDropData(data)) {
         const list = findContainerList(blocks, data.containerId) ?? [];
-        return { containerId: data.containerId, index: list.length };
+        const r = over.rect;
+
+        if (list.length === 0) {
+            return {
+                containerId: data.containerId,
+                index: 0,
+                indicator: { kind: 'empty', top: r.top, left: r.left, width: r.width, height: r.height },
+            };
+        }
+
+        // 中身があるコンテナの余白(パディング等、どのブロックの矩形にも含まれない隙間)にホバーした場合。
+        // コンテナ全体をハイライトすると中身を全部置き換えるように見えて誤解を招くため、
+        // 末尾のブロックの直後に挿入される線インジケーターを表示する
+        const lastBlockId = list[list.length - 1].id;
+        const lastNode = document.querySelector<HTMLElement>(`[data-slide-canvas] [data-block-id="${lastBlockId}"]`);
+        const lastRect = lastNode?.getBoundingClientRect();
+
+        return {
+            containerId: data.containerId,
+            index: list.length,
+            indicator: lastRect
+                ? { kind: 'line', top: lastRect.bottom, left: lastRect.left, width: lastRect.width }
+                : { kind: 'empty', top: r.top, left: r.left, width: r.width, height: r.height },
+        };
     }
+
+    if (isSortableItemData(data)) {
+        const overRect = over.rect;
+        const activeRect = active.rect.current.translated;
+        const isAfter = !!(
+            activeRect &&
+            activeRect.top + activeRect.height / 2 > overRect.top + overRect.height / 2
+        );
+        return {
+            containerId: data.sortable.containerId,
+            index: data.sortable.index + (isAfter ? 1 : 0),
+            indicator: {
+                kind: 'line',
+                top: isAfter ? overRect.top + overRect.height : overRect.top,
+                left: overRect.left,
+                width: overRect.width,
+            },
+        };
+    }
+
     return null;
 }
+
+// closestCenterはドラッグ中の要素自身の矩形の中心同士を比較するため、
+// ルート直下のフル幅ブロックのように「元の矩形が持ち先(列など)よりずっと大きい」場合、
+// 矩形の中心が実際のポインタ位置から大きくズレて誤ったコンテナに判定されてしまう。
+// そのため、まず実際のポインタ位置で当たっているコンテナを優先し(pointerWithin)、
+// どこにも当たっていない場合(キーボード操作時など)だけclosestCenterにフォールバックする
+const collisionDetection: CollisionDetection = (args) => {
+    const pointerCollisions = pointerWithin(args);
+    if (pointerCollisions.length > 0) {
+        return pointerCollisions;
+    }
+    return closestCenter(args);
+};
 
 function getCurrentBlocks(): BlockData[] {
     const state = useEditorStore.getState();
     return state.slides.find((s) => s.id === state.activeSlideId)?.blocks ?? [];
 }
 
+// ドラッグ中に浮かせて表示するプレビュー(DragOverlayの中身)
+type DragPreview =
+    | { kind: 'block'; blockId: string; width: number; height: number }
+    | { kind: 'palette'; blockType: BlockType };
+
 export default function EditorBlockDndContext({ children }: { children: React.ReactNode }) {
     const slides = useEditorStore((state) => state.slides);
     const activeSlideId = useEditorStore((state) => state.activeSlideId);
     const moveBlock = useEditorStore((state) => state.moveBlock);
     const spawnBlockAt = useEditorStore((state) => state.spawnBlockAt);
-    const removeBlock = useEditorStore((state) => state.removeBlock);
     const setSelectedBlockId = useEditorStore((state) => state.setSelectedBlockId);
 
     const blocks = slides.find((s) => s.id === activeSlideId)?.blocks ?? [];
 
-    const [draggedBlockId, setDraggedBlockId] = useState<string | null>(null);
-    const [overlaySize, setOverlaySize] = useState<{ width: number; height: number } | null>(null);
-    // BlockSelectorからのドラッグで新規生成したブロックのID(通常ブロックのドラッグではnull)
-    const spawnedBlockIdRef = useRef<string | null>(null);
-    // 直前にコンテナ間移動を適用した(containerId, index)を覚えておき、同じ移動を無駄に繰り返さないようにする。
-    // また、何らかの理由でホバー先の判定が高頻度に往復し続けるケースに備えて、
-    // 1回のドラッグ操作あたりの移動回数に上限を設け、無限ループ的な状態更新の連鎖を防ぐ
-    const lastAppliedMoveRef = useRef<{ containerId: string; index: number } | null>(null);
-    const moveCountRef = useRef(0);
-    const MAX_MOVES_PER_DRAG = 5000;
-
-    // onDragOverはポインタが動くたびに(ブラウザのイベント頻度次第で1フレームに何度も)発火しうる。
-    // 呼ばれるたびに同期的にmoveBlockを実行すると、コンテナ境界付近での高頻度なホバー切り替え時に
-    // Reactの再レンダーが追いつかないまま状態更新が連鎖し、「Maximum update depth exceeded」につながる。
-    // そのため実際の移動は requestAnimationFrame で1フレームにつき最大1回にまとめて適用する
-    const rafIdRef = useRef<number | null>(null);
-    const pendingMoveRef = useRef<{ activeBlockId: string; containerId: string; index: number } | null>(null);
-
-    const cancelPendingMove = () => {
-        if (rafIdRef.current !== null) {
-            cancelAnimationFrame(rafIdRef.current);
-            rafIdRef.current = null;
-        }
-        pendingMoveRef.current = null;
-    };
-
-    const flushPendingMove = () => {
-        rafIdRef.current = null;
-        const pending = pendingMoveRef.current;
-        pendingMoveRef.current = null;
-        if (!pending) return;
-
-        const last = lastAppliedMoveRef.current;
-        if (last && last.containerId === pending.containerId && last.index === pending.index) return;
-        if (moveCountRef.current >= MAX_MOVES_PER_DRAG) return;
-
-        moveBlock(pending.activeBlockId, pending.containerId, pending.index);
-        lastAppliedMoveRef.current = { containerId: pending.containerId, index: pending.index };
-        moveCountRef.current += 1;
-    };
+    const [dragPreview, setDragPreview] = useState<DragPreview | null>(null);
+    const [indicator, setIndicator] = useState<Indicator | null>(null);
 
     const sensors = useSensors(
         useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
@@ -123,92 +154,61 @@ export default function EditorBlockDndContext({ children }: { children: React.Re
         const { active } = event;
         const data = active.data.current;
 
-        cancelPendingMove();
-        lastAppliedMoveRef.current = null;
-        moveCountRef.current = 0;
-
         if (isPaletteDragData(data)) {
-            const defaultParams = BLOCK_DEFAULTS[data.blockType] ?? {};
-            // その場では位置を確定させず、末尾に生成してから dragOver/dragEnd で本来の位置に移動させる。
-            // パレットからの新規配置は、この後リアルタイムに実データが動く様子自体がプレビューになるため
-            // DragOverlayは出さない(元々サイズを持たないボタンなので固定サイズのプレビューにする意味が薄い)
-            const blockId = spawnBlockAt(data.blockType, defaultParams, ROOT_CONTAINER_ID, getCurrentBlocks().length);
-            spawnedBlockIdRef.current = blockId;
-            setDraggedBlockId(null);
-            setOverlaySize(null);
+            setDragPreview({ kind: 'palette', blockType: data.blockType });
             return;
         }
 
-        spawnedBlockIdRef.current = null;
         const blockId = active.id as string;
-        setDraggedBlockId(blockId);
-
         // dnd-kitのactive.rect.current.initialはこの時点ではまだ計測されていないことがあるため、
-        // 実DOMのサイズを直接測ってドラッグ中に表示するプレビューのサイズを固定する
-        const node = document.querySelector<HTMLElement>(`[data-block-id="${blockId}"]`);
+        // 実DOMのサイズを直接測ってドラッグ中に表示するプレビューのサイズを固定する。
+        // SlideNavigatorのミニプレビューも(2列ブロックの中身に限り)同じSortableBlockItemを再利用しており
+        // 同じdata-block-idを持つ縮小コピーが存在するため、実キャンバス内に限定して探す
+        const node = document.querySelector<HTMLElement>(`[data-slide-canvas] [data-block-id="${blockId}"]`);
         const rect = node?.getBoundingClientRect();
-        setOverlaySize(rect ? { width: rect.width, height: rect.height } : null);
+        setDragPreview({ kind: 'block', blockId, width: rect?.width ?? 0, height: rect?.height ?? 0 });
     };
 
+    // ドラッグ中は実データを一切動かさず、挿入位置のインジケーターだけを更新する
     const handleDragOver = (event: DragOverEvent) => {
-        const activeBlockId = spawnedBlockIdRef.current ?? (event.active.id as string);
-        const currentBlocks = getCurrentBlocks();
-
-        const target = resolveOverTarget(event.over, currentBlocks);
-        if (!target) return;
-
-        const activeContainerId = findContainerIdForBlock(currentBlocks, activeBlockId);
-        if (!activeContainerId || activeContainerId === target.containerId) return;
-
-        // 他コンテナへのホバー: 実データの移動(リアルタイムに詰めて表示する処理)は
-        // 次の描画フレームでまとめて適用する(flushPendingMove参照)
-        pendingMoveRef.current = { activeBlockId, containerId: target.containerId, index: target.index };
-        if (rafIdRef.current === null) {
-            rafIdRef.current = requestAnimationFrame(flushPendingMove);
-        }
+        const resolved = resolveDrag(event.active, event.over, getCurrentBlocks());
+        setIndicator(resolved?.indicator ?? null);
     };
 
+    // 実データの移動/新規挿入は、ドロップされた瞬間に一度だけ行う
     const handleDragEnd = (event: DragEndEvent) => {
-        cancelPendingMove();
-        const activeBlockId = spawnedBlockIdRef.current ?? (event.active.id as string);
-        const currentBlocks = getCurrentBlocks();
-        const target = resolveOverTarget(event.over, currentBlocks);
+        const { active, over } = event;
+        const data = active.data.current;
+        const resolved = resolveDrag(active, over, getCurrentBlocks());
 
-        if (!target) {
-            // 有効なドロップ先が無いままリリースされた場合、パレットからの新規生成分は取り消す
-            if (spawnedBlockIdRef.current) {
-                removeBlock(spawnedBlockIdRef.current);
-            }
-        } else {
-            // 同一コンテナ内での最終的な並び順を確定する(別コンテナへはdragOverで移動済み)
-            moveBlock(activeBlockId, target.containerId, target.index);
-            if (spawnedBlockIdRef.current) {
-                setSelectedBlockId(spawnedBlockIdRef.current);
+        if (resolved) {
+            if (isPaletteDragData(data)) {
+                const defaultParams = BLOCK_DEFAULTS[data.blockType] ?? {};
+                const newBlockId = spawnBlockAt(data.blockType, defaultParams, resolved.containerId, resolved.index);
+                setSelectedBlockId(newBlockId);
+            } else {
+                moveBlock(active.id as string, resolved.containerId, resolved.index);
             }
         }
+        // 有効なドロップ先が無い場合は何もしない。実データはまだ動いていないので後始末は不要
 
-        spawnedBlockIdRef.current = null;
-        setDraggedBlockId(null);
-        setOverlaySize(null);
+        setDragPreview(null);
+        setIndicator(null);
     };
 
     const handleDragCancel = () => {
-        cancelPendingMove();
-        if (spawnedBlockIdRef.current) {
-            removeBlock(spawnedBlockIdRef.current);
-        }
-        spawnedBlockIdRef.current = null;
-        setDraggedBlockId(null);
-        setOverlaySize(null);
+        setDragPreview(null);
+        setIndicator(null);
     };
 
-    const draggedBlock = draggedBlockId ? findBlockById(blocks, draggedBlockId) : undefined;
+    const draggedBlock = dragPreview?.kind === 'block' ? findBlockById(blocks, dragPreview.blockId) : undefined;
+    const paletteItem = dragPreview?.kind === 'palette' ? PALETTE_ITEMS_BY_TYPE[dragPreview.blockType] : undefined;
 
     return (
         <DndContext
             id="editor-block-dnd-context"
             sensors={sensors}
-            collisionDetection={closestCenter}
+            collisionDetection={collisionDetection}
             onDragStart={handleDragStart}
             onDragOver={handleDragOver}
             onDragEnd={handleDragEnd}
@@ -216,13 +216,38 @@ export default function EditorBlockDndContext({ children }: { children: React.Re
         >
             {children}
 
+            {indicator?.kind === 'line' && (
+                <div
+                    style={{ position: 'fixed', top: indicator.top - 1, left: indicator.left, width: indicator.width }}
+                    className="h-[3px] bg-blue-500 rounded-full pointer-events-none z-[60]"
+                />
+            )}
+            {indicator?.kind === 'empty' && (
+                <div
+                    style={{
+                        position: 'fixed',
+                        top: indicator.top,
+                        left: indicator.left,
+                        width: indicator.width,
+                        height: indicator.height,
+                    }}
+                    className="border-2 border-blue-400 bg-blue-50/40 rounded-lg pointer-events-none z-[60]"
+                />
+            )}
+
             <DragOverlay dropAnimation={{ duration: 200, easing: 'cubic-bezier(0.18, 0.67, 0.6, 1.22)' }}>
-                {draggedBlock && overlaySize ? (
+                {dragPreview?.kind === 'block' && draggedBlock ? (
                     <div
-                        style={{ width: overlaySize.width, height: overlaySize.height }}
+                        style={{ width: dragPreview.width, height: dragPreview.height }}
                         className="pointer-events-none overflow-hidden rounded-lg border-2 border-blue-400 bg-white p-4 shadow-xl"
                     >
                         <Block block={draggedBlock} />
+                    </div>
+                ) : null}
+                {dragPreview?.kind === 'palette' && paletteItem ? (
+                    <div className="pointer-events-none flex items-center gap-2 rounded-lg border-2 border-blue-400 bg-white px-3 py-2 text-sm text-gray-700 shadow-xl">
+                        {paletteItem.icon && <paletteItem.icon className="w-4 h-4" />}
+                        {paletteItem.label}
                     </div>
                 ) : null}
             </DragOverlay>

--- a/src/components/editor/EditorBlockDndContext.tsx
+++ b/src/components/editor/EditorBlockDndContext.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import {
+    DndContext,
+    DragOverlay,
+    KeyboardSensor,
+    PointerSensor,
+    closestCenter,
+    useSensor,
+    useSensors,
+} from '@dnd-kit/core';
+import type { DragStartEvent, DragOverEvent, DragEndEvent, Over } from '@dnd-kit/core';
+import { sortableKeyboardCoordinates } from '@dnd-kit/sortable';
+
+import { useEditorStore } from '@/stores/useEditorStore';
+import { BLOCK_DEFAULTS } from '@/components/blocks/defaults';
+import Block from '@/components/blocks/Block';
+import {
+    ROOT_CONTAINER_ID,
+    findBlockById,
+    findContainerIdForBlock,
+    findContainerList,
+} from '@/lib/blockTree';
+import type { BlockData, BlockType } from '@/types/block';
+
+// BlockSelectorのボタンをドラッグ開始したときに active.data に載せる情報
+export type PaletteDragData = { source: 'palette'; blockType: BlockType };
+
+function isPaletteDragData(data: unknown): data is PaletteDragData {
+    return !!data && typeof data === 'object' && (data as PaletteDragData).source === 'palette';
+}
+
+type SortableItemData = { sortable: { containerId: string; index: number } };
+
+function isSortableItemData(data: unknown): data is SortableItemData {
+    return !!data && typeof data === 'object' && 'sortable' in (data as Record<string, unknown>);
+}
+
+type ContainerDropData = { type: 'container'; containerId: string };
+
+function isContainerDropData(data: unknown): data is ContainerDropData {
+    return !!data && typeof data === 'object' && (data as ContainerDropData).type === 'container';
+}
+
+// over(ドロップ先候補)から「どのコンテナの何番目に置こうとしているか」を求める
+function resolveOverTarget(over: Over | null, blocks: BlockData[]): { containerId: string; index: number } | null {
+    if (!over) return null;
+
+    const data = over.data.current;
+    if (isSortableItemData(data)) {
+        return { containerId: data.sortable.containerId, index: data.sortable.index };
+    }
+    if (isContainerDropData(data)) {
+        const list = findContainerList(blocks, data.containerId) ?? [];
+        return { containerId: data.containerId, index: list.length };
+    }
+    return null;
+}
+
+function getCurrentBlocks(): BlockData[] {
+    const state = useEditorStore.getState();
+    return state.slides.find((s) => s.id === state.activeSlideId)?.blocks ?? [];
+}
+
+export default function EditorBlockDndContext({ children }: { children: React.ReactNode }) {
+    const slides = useEditorStore((state) => state.slides);
+    const activeSlideId = useEditorStore((state) => state.activeSlideId);
+    const moveBlock = useEditorStore((state) => state.moveBlock);
+    const spawnBlockAt = useEditorStore((state) => state.spawnBlockAt);
+    const removeBlock = useEditorStore((state) => state.removeBlock);
+    const setSelectedBlockId = useEditorStore((state) => state.setSelectedBlockId);
+
+    const blocks = slides.find((s) => s.id === activeSlideId)?.blocks ?? [];
+
+    const [draggedBlockId, setDraggedBlockId] = useState<string | null>(null);
+    const [overlaySize, setOverlaySize] = useState<{ width: number; height: number } | null>(null);
+    // BlockSelectorからのドラッグで新規生成したブロックのID(通常ブロックのドラッグではnull)
+    const spawnedBlockIdRef = useRef<string | null>(null);
+    // 直前にコンテナ間移動を適用した(containerId, index)を覚えておき、同じ移動を無駄に繰り返さないようにする。
+    // また、何らかの理由でホバー先の判定が高頻度に往復し続けるケースに備えて、
+    // 1回のドラッグ操作あたりの移動回数に上限を設け、無限ループ的な状態更新の連鎖を防ぐ
+    const lastAppliedMoveRef = useRef<{ containerId: string; index: number } | null>(null);
+    const moveCountRef = useRef(0);
+    const MAX_MOVES_PER_DRAG = 5000;
+
+    // onDragOverはポインタが動くたびに(ブラウザのイベント頻度次第で1フレームに何度も)発火しうる。
+    // 呼ばれるたびに同期的にmoveBlockを実行すると、コンテナ境界付近での高頻度なホバー切り替え時に
+    // Reactの再レンダーが追いつかないまま状態更新が連鎖し、「Maximum update depth exceeded」につながる。
+    // そのため実際の移動は requestAnimationFrame で1フレームにつき最大1回にまとめて適用する
+    const rafIdRef = useRef<number | null>(null);
+    const pendingMoveRef = useRef<{ activeBlockId: string; containerId: string; index: number } | null>(null);
+
+    const cancelPendingMove = () => {
+        if (rafIdRef.current !== null) {
+            cancelAnimationFrame(rafIdRef.current);
+            rafIdRef.current = null;
+        }
+        pendingMoveRef.current = null;
+    };
+
+    const flushPendingMove = () => {
+        rafIdRef.current = null;
+        const pending = pendingMoveRef.current;
+        pendingMoveRef.current = null;
+        if (!pending) return;
+
+        const last = lastAppliedMoveRef.current;
+        if (last && last.containerId === pending.containerId && last.index === pending.index) return;
+        if (moveCountRef.current >= MAX_MOVES_PER_DRAG) return;
+
+        moveBlock(pending.activeBlockId, pending.containerId, pending.index);
+        lastAppliedMoveRef.current = { containerId: pending.containerId, index: pending.index };
+        moveCountRef.current += 1;
+    };
+
+    const sensors = useSensors(
+        useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+        useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+    );
+
+    const handleDragStart = (event: DragStartEvent) => {
+        const { active } = event;
+        const data = active.data.current;
+
+        cancelPendingMove();
+        lastAppliedMoveRef.current = null;
+        moveCountRef.current = 0;
+
+        if (isPaletteDragData(data)) {
+            const defaultParams = BLOCK_DEFAULTS[data.blockType] ?? {};
+            // その場では位置を確定させず、末尾に生成してから dragOver/dragEnd で本来の位置に移動させる。
+            // パレットからの新規配置は、この後リアルタイムに実データが動く様子自体がプレビューになるため
+            // DragOverlayは出さない(元々サイズを持たないボタンなので固定サイズのプレビューにする意味が薄い)
+            const blockId = spawnBlockAt(data.blockType, defaultParams, ROOT_CONTAINER_ID, getCurrentBlocks().length);
+            spawnedBlockIdRef.current = blockId;
+            setDraggedBlockId(null);
+            setOverlaySize(null);
+            return;
+        }
+
+        spawnedBlockIdRef.current = null;
+        const blockId = active.id as string;
+        setDraggedBlockId(blockId);
+
+        // dnd-kitのactive.rect.current.initialはこの時点ではまだ計測されていないことがあるため、
+        // 実DOMのサイズを直接測ってドラッグ中に表示するプレビューのサイズを固定する
+        const node = document.querySelector<HTMLElement>(`[data-block-id="${blockId}"]`);
+        const rect = node?.getBoundingClientRect();
+        setOverlaySize(rect ? { width: rect.width, height: rect.height } : null);
+    };
+
+    const handleDragOver = (event: DragOverEvent) => {
+        const activeBlockId = spawnedBlockIdRef.current ?? (event.active.id as string);
+        const currentBlocks = getCurrentBlocks();
+
+        const target = resolveOverTarget(event.over, currentBlocks);
+        if (!target) return;
+
+        const activeContainerId = findContainerIdForBlock(currentBlocks, activeBlockId);
+        if (!activeContainerId || activeContainerId === target.containerId) return;
+
+        // 他コンテナへのホバー: 実データの移動(リアルタイムに詰めて表示する処理)は
+        // 次の描画フレームでまとめて適用する(flushPendingMove参照)
+        pendingMoveRef.current = { activeBlockId, containerId: target.containerId, index: target.index };
+        if (rafIdRef.current === null) {
+            rafIdRef.current = requestAnimationFrame(flushPendingMove);
+        }
+    };
+
+    const handleDragEnd = (event: DragEndEvent) => {
+        cancelPendingMove();
+        const activeBlockId = spawnedBlockIdRef.current ?? (event.active.id as string);
+        const currentBlocks = getCurrentBlocks();
+        const target = resolveOverTarget(event.over, currentBlocks);
+
+        if (!target) {
+            // 有効なドロップ先が無いままリリースされた場合、パレットからの新規生成分は取り消す
+            if (spawnedBlockIdRef.current) {
+                removeBlock(spawnedBlockIdRef.current);
+            }
+        } else {
+            // 同一コンテナ内での最終的な並び順を確定する(別コンテナへはdragOverで移動済み)
+            moveBlock(activeBlockId, target.containerId, target.index);
+            if (spawnedBlockIdRef.current) {
+                setSelectedBlockId(spawnedBlockIdRef.current);
+            }
+        }
+
+        spawnedBlockIdRef.current = null;
+        setDraggedBlockId(null);
+        setOverlaySize(null);
+    };
+
+    const handleDragCancel = () => {
+        cancelPendingMove();
+        if (spawnedBlockIdRef.current) {
+            removeBlock(spawnedBlockIdRef.current);
+        }
+        spawnedBlockIdRef.current = null;
+        setDraggedBlockId(null);
+        setOverlaySize(null);
+    };
+
+    const draggedBlock = draggedBlockId ? findBlockById(blocks, draggedBlockId) : undefined;
+
+    return (
+        <DndContext
+            id="editor-block-dnd-context"
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragStart={handleDragStart}
+            onDragOver={handleDragOver}
+            onDragEnd={handleDragEnd}
+            onDragCancel={handleDragCancel}
+        >
+            {children}
+
+            <DragOverlay dropAnimation={{ duration: 200, easing: 'cubic-bezier(0.18, 0.67, 0.6, 1.22)' }}>
+                {draggedBlock && overlaySize ? (
+                    <div
+                        style={{ width: overlaySize.width, height: overlaySize.height }}
+                        className="pointer-events-none overflow-hidden rounded-lg border-2 border-blue-400 bg-white p-4 shadow-xl"
+                    >
+                        <Block block={draggedBlock} />
+                    </div>
+                ) : null}
+            </DragOverlay>
+        </DndContext>
+    );
+}

--- a/src/components/editor/SlideCanvas.tsx
+++ b/src/components/editor/SlideCanvas.tsx
@@ -19,7 +19,10 @@ export default function SlideCanvas() {
     });
 
     return (
-        <div className="w-[85vw] max-w-[1024px] aspect-video bg-white shadow-sm border border-gray-300 relative mt-8 flex flex-col z-0">
+        <div
+            data-slide-canvas
+            className="w-[85vw] max-w-[1024px] aspect-video bg-white shadow-sm border border-gray-300 relative mt-8 flex flex-col z-0"
+        >
             <div ref={setNodeRef} className="p-8 flex-1 overflow-y-auto">
                 <SortableContext
                     id={ROOT_CONTAINER_ID}

--- a/src/components/editor/SlideCanvas.tsx
+++ b/src/components/editor/SlideCanvas.tsx
@@ -1,61 +1,44 @@
 'use client';
 
-import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useSensor, useSensors, DragEndEvent } from '@dnd-kit/core';
-import { SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy } from '@dnd-kit/sortable';
-import { restrictToVerticalAxis, restrictToFirstScrollableAncestor } from '@dnd-kit/modifiers';
+import { useDroppable } from '@dnd-kit/core';
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 
 import { useEditorStore } from '@/stores/useEditorStore';
 import SortableBlockItem from '@/components/blocks/SortableBlockItem';
+import { ROOT_CONTAINER_ID } from '@/lib/blockTree';
 
 // --- メインのキャンバス ---
 export default function SlideCanvas() {
     const slides = useEditorStore((state) => state.slides);
     const activeSlideId = useEditorStore((state) => state.activeSlideId);
-    const moveBlock = useEditorStore((state) => state.moveBlock);
     const currentSlide = slides.find(s => s.id === activeSlideId);
 
-    const sensors = useSensors(
-        useSensor(PointerSensor),
-        useSensor(KeyboardSensor, {
-            coordinateGetter: sortableKeyboardCoordinates,
-        })
-    );
-
-    const handleDragEnd = (event: DragEndEvent) => {
-        const { active, over } = event;
-        if (over && active.id !== over.id) {
-            moveBlock(active.id as string, over.id as string);
-        }
-    };
+    const { setNodeRef } = useDroppable({
+        id: ROOT_CONTAINER_ID,
+        data: { type: 'container', containerId: ROOT_CONTAINER_ID },
+    });
 
     return (
         <div className="w-[85vw] max-w-[1024px] aspect-video bg-white shadow-sm border border-gray-300 relative mt-8 flex flex-col z-0">
-            <DndContext 
-                id="block-dnd-context"
-                sensors={sensors} 
-                collisionDetection={closestCenter} 
-                modifiers={[restrictToVerticalAxis, restrictToFirstScrollableAncestor]}
-                onDragEnd={handleDragEnd}
-            >
-                <div className="p-8 flex-1 overflow-y-auto">
-                    <SortableContext 
-                        items={currentSlide?.blocks.map(b => b.id) || []} 
-                        strategy={verticalListSortingStrategy}
-                    >
-                        <div className="flex flex-col gap-2">
-                            {currentSlide?.blocks.map((block) => (
-                                <SortableBlockItem key={block.id} block={block} />
-                            ))}
+            <div ref={setNodeRef} className="p-8 flex-1 overflow-y-auto">
+                <SortableContext
+                    id={ROOT_CONTAINER_ID}
+                    items={currentSlide?.blocks.map(b => b.id) || []}
+                    strategy={verticalListSortingStrategy}
+                >
+                    <div className="flex flex-col gap-2 min-h-full">
+                        {currentSlide?.blocks.map((block) => (
+                            <SortableBlockItem key={block.id} block={block} />
+                        ))}
 
-                            {currentSlide?.blocks.length === 0 && (
-                                <div className="py-12 border-2 border-dashed border-gray-300 rounded-lg text-center text-gray-400">
-                                    パレットから要素を追加してください
-                                </div>
-                            )}
-                        </div>
-                    </SortableContext>
-                </div>
-            </DndContext>
+                        {currentSlide?.blocks.length === 0 && (
+                            <div className="py-12 border-2 border-dashed border-gray-300 rounded-lg text-center text-gray-400">
+                                パレットから要素を追加してください
+                            </div>
+                        )}
+                    </div>
+                </SortableContext>
+            </div>
         </div>
     );
 }

--- a/src/lib/blockTree.ts
+++ b/src/lib/blockTree.ts
@@ -1,5 +1,8 @@
 import type { BlockData } from '@/types/block';
 
+// トップレベルのブロック一覧を表す仮想的なコンテナID。2列ブロックの列は `${twoColumnBlockId}:${columnIndex}` で表す
+export const ROOT_CONTAINER_ID = 'root';
+
 // ブロック配列（2列ブロックの列内も含む）を再帰的に辿り、指定IDのブロックを探す
 export function findBlockById(blocks: BlockData[], id: string): BlockData | undefined {
   for (const block of blocks) {
@@ -26,4 +29,53 @@ export function findParentList(blocks: BlockData[], id: string): BlockData[] | u
     }
   }
   return undefined;
+}
+
+// コンテナID(トップレベルなら ROOT_CONTAINER_ID、列なら `${twoColumnBlockId}:${columnIndex}`)から
+// 実際のブロック配列を取得する
+export function findContainerList(blocks: BlockData[], containerId: string): BlockData[] | undefined {
+  if (containerId === ROOT_CONTAINER_ID) return blocks;
+
+  const separatorIndex = containerId.lastIndexOf(':');
+  if (separatorIndex === -1) return undefined;
+
+  const blockId = containerId.slice(0, separatorIndex);
+  const columnIndex = Number(containerId.slice(separatorIndex + 1));
+
+  const block = findBlockById(blocks, blockId);
+  if (block && block.type === 'two-column') {
+    return block.parameters.columns[columnIndex];
+  }
+  return undefined;
+}
+
+// 指定したブロックが現在属しているコンテナID(トップレベル or 列)を返す
+export function findContainerIdForBlock(
+  blocks: BlockData[],
+  blockId: string,
+  containerId: string = ROOT_CONTAINER_ID
+): string | undefined {
+  if (blocks.some((b) => b.id === blockId)) return containerId;
+
+  for (const block of blocks) {
+    if (block.type === 'two-column') {
+      for (let i = 0; i < block.parameters.columns.length; i++) {
+        const found = findContainerIdForBlock(block.parameters.columns[i], blockId, `${block.id}:${i}`);
+        if (found) return found;
+      }
+    }
+  }
+  return undefined;
+}
+
+// 指定したコンテナIDが、ブロック自身またはその子孫(ネストした2列ブロックの列)の中にあるかどうかを判定する。
+// 2列ブロックを自分自身/自分の子孫の列にドロップして循環参照になるのを防ぐために使う
+export function isContainerInsideBlock(block: BlockData, containerId: string): boolean {
+  if (block.type !== 'two-column') return false;
+
+  for (let i = 0; i < block.parameters.columns.length; i++) {
+    if (`${block.id}:${i}` === containerId) return true;
+    if (block.parameters.columns[i].some((child) => isContainerInsideBlock(child, containerId))) return true;
+  }
+  return false;
 }

--- a/src/stores/useEditorStore.ts
+++ b/src/stores/useEditorStore.ts
@@ -2,7 +2,31 @@ import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 import type { BlockType, BlockData } from '@/types/block';
 import type { SlideData } from '@/types/slide';
-import { findBlockById, findParentList } from '@/lib/blockTree';
+import {
+  findBlockById,
+  findParentList,
+  findContainerList,
+  isContainerInsideBlock,
+} from '@/lib/blockTree';
+
+// 2列ブロックは、左右の列にそれぞれ空のテキストブロックを入れた状態で生成する
+// (デフォルト値をそのまま使うと複数の2列ブロックが列の配列を共有してしまうため、都度生成する)
+// (呼び出し元のジェネリックTをそのまま受け取ると型推論が破綻するため、あえて非ジェネリックにしてBlockData['parameters']で受ける)
+function buildNewBlock(type: BlockType, initialParams: BlockData['parameters']): BlockData {
+  const newBlock = {
+    id: crypto.randomUUID(),
+    type,
+    parameters: initialParams,
+  } as BlockData;
+
+  if (newBlock.type === 'two-column') {
+    const leftBlock: BlockData = { id: crypto.randomUUID(), type: 'text', parameters: { content: '' } };
+    const rightBlock: BlockData = { id: crypto.randomUUID(), type: 'text', parameters: { content: '' } };
+    newBlock.parameters = { ratio: 0.5, columns: [[leftBlock], [rightBlock]] };
+  }
+
+  return newBlock;
+}
 
 interface EditorState {
   // 状態 (State)
@@ -17,10 +41,19 @@ interface EditorState {
     type: T,
     initialParams: Extract<BlockData, { type: T }>['parameters']
   ) => void;
+  // 指定したコンテナ(トップレベル or 2列ブロックの列)の指定位置に新規ブロックを生成して挿入し、生成したブロックのIDを返す
+  spawnBlockAt: <T extends BlockType>(
+    type: T,
+    initialParams: Extract<BlockData, { type: T }>['parameters'],
+    containerId: string,
+    index: number
+  ) => string;
   setSelectedBlockId: (id: string | null) => void;
   updateBlockParams: (id: string, newParams: Partial<BlockData['parameters']>) => void;
   removeBlock: (id: string) => void;
-  moveBlock: (activeId: string, overId: string) => void;
+  // 指定したブロックを、指定したコンテナ(トップレベル or 2列ブロックの列)の指定位置に移動する。
+  // 同じコンテナ内での並び替え・別コンテナ(別の列など)への移動の両方に対応する
+  moveBlock: (blockId: string, containerId: string, index: number) => void;
   addSlide: () => void;
   setActiveSlideId: (id: string) => void;
   deleteSlide: (id: string) => void;
@@ -44,21 +77,8 @@ export const useEditorStore = create<EditorState>()(
       const currentSlide = state.slides.find(s => s.id === state.activeSlideId);
       if (!currentSlide) return;
 
-      const newBlock = {
-        id: crypto.randomUUID(),
-        type,
-        parameters: initialParams,
-      } as BlockData;
-
-      // 2列ブロックは、左右の列にそれぞれ空のテキストブロックを入れた状態で追加する
-      // (デフォルト値をそのまま使うと複数の2列ブロックが列の配列を共有してしまうため、都度生成する)
-      let selectAfterInsert = newBlock.id;
-      if (newBlock.type === 'two-column') {
-        const leftBlock: BlockData = { id: crypto.randomUUID(), type: 'text', parameters: { content: '' } };
-        const rightBlock: BlockData = { id: crypto.randomUUID(), type: 'text', parameters: { content: '' } };
-        newBlock.parameters = { ratio: 0.5, columns: [[leftBlock], [rightBlock]] };
-        selectAfterInsert = leftBlock.id;
-      }
+      const newBlock = buildNewBlock(type, initialParams);
+      const selectAfterInsert = newBlock.type === 'two-column' ? newBlock.parameters.columns[0][0].id : newBlock.id;
 
       // 選択中のブロックがあれば、その直後(同じ階層)に挿入する
       const list = state.selectedBlockId
@@ -74,6 +94,23 @@ export const useEditorStore = create<EditorState>()(
 
       state.selectedBlockId = selectAfterInsert;
     }),
+
+    // --- コンテナ(トップレベル or 2列ブロックの列)の指定位置へブロックを新規生成して挿入 ---
+    spawnBlockAt: (type, initialParams, containerId, index) => {
+      const newBlock = buildNewBlock(type, initialParams);
+
+      set((state) => {
+        const currentSlide = state.slides.find(s => s.id === state.activeSlideId);
+        if (!currentSlide) return;
+
+        const list = findContainerList(currentSlide.blocks, containerId) ?? currentSlide.blocks;
+        const insertIndex = Math.max(0, Math.min(index, list.length));
+        list.splice(insertIndex, 0, newBlock);
+        state.selectedBlockId = newBlock.id;
+      });
+
+      return newBlock.id;
+    },
 
     // --- 選択中ブロックの切り替え ---
     setSelectedBlockId: (id) => set((state) => {
@@ -116,20 +153,32 @@ export const useEditorStore = create<EditorState>()(
     }),
 
     // --- ブロックの移動 ---
-    moveBlock: (activeId, overId) => set((state) => {
+    // 同じコンテナ内での並び替えと、別コンテナ(トップレベル ⇔ 2列ブロックの列、列 ⇔ 別の列)への移動を両方扱う。
+    // 別コンテナへの移動は source から取り除いてから dest の index に挿入するだけで良く、
+    // 同じコンテナ内の移動も「取り除いてから挿入」で arrayMove と同じ結果になる
+    moveBlock: (blockId, containerId, index) => set((state) => {
       const currentSlide = state.slides.find(s => s.id === state.activeSlideId);
       if (!currentSlide) return;
 
-      const list = findParentList(currentSlide.blocks, activeId);
-      if (!list) return;
+      const block = findBlockById(currentSlide.blocks, blockId);
+      const sourceList = findParentList(currentSlide.blocks, blockId);
+      if (!block || !sourceList) return;
 
-      const oldIndex = list.findIndex(b => b.id === activeId);
-      const newIndex = list.findIndex(b => b.id === overId);
+      // 2列ブロックを自分自身や自分の子孫の列に移動するのは循環になるため禁止
+      if (isContainerInsideBlock(block, containerId)) return;
 
-      if (oldIndex !== -1 && newIndex !== -1 && oldIndex !== newIndex) {
-        const [movedBlock] = list.splice(oldIndex, 1);
-        list.splice(newIndex, 0, movedBlock);
-      }
+      const destList = findContainerList(currentSlide.blocks, containerId);
+      if (!destList) return;
+
+      const sourceIndex = sourceList.findIndex(b => b.id === blockId);
+      if (sourceIndex === -1) return;
+
+      const isSameList = sourceList === destList;
+      if (isSameList && sourceIndex === index) return;
+
+      sourceList.splice(sourceIndex, 1);
+      const insertIndex = Math.max(0, Math.min(index, destList.length));
+      destList.splice(insertIndex, 0, block);
     }),
 
     // --- スライドの追加 ---


### PR DESCRIPTION
## 概要
Editorのブロックのドラッグ&ドロップまわりを全面的に見直しました。

## 変更内容
- 2列ブロックの列をまたいだブロック移動に対応
- ブロックを持ち上げている間、比率(サイズ)が変化しないよう修正
- BlockSelectorからドラッグ&ドロップで新規ブロックを配置できるように対応
- ドラッグ中は実データを動かさず、挿入位置をインジケーター(線 or ハイライト枠)で示し、ドロップ時に一度だけ確定する方式に設計を刷新(Notionのブロック移動を参考)
- 上記に伴い発生した以下の不具合を修正
  - 列の境界付近での高頻度なホバーでクラッシュする問題(Maximum update depth exceeded)
  - 2列ブロック内のブロックを持ち上げた際、DragOverlayのプレビューが縮小されて表示される問題
  - 幅の広いブロックを2列の列にドラッグすると、ポインタ位置と判定がズレて意図しない場所に配置される問題(衝突判定をpointerWithin優先に変更)
  - 中身のあるコンテナの余白にホバーした際、誤ってコンテナ全体が青くハイライトされる問題